### PR TITLE
Upgrading phpstan & infection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
     "require-dev": {
         "ciaranmcnulty/phpspec-typehintedmethods": "^3.0",
         "friendsofphp/php-cs-fixer": "dev-long-line-fixers",
-        "infection/infection": "^0.8.1",
+        "infection/infection": "^0.9@dev",
         "leanphp/phpspec-code-coverage": "^4.0",
         "mockery/mockery": "^1.0",
         "phing/phing": "^2.16",
         "phpmd/phpmd": "^2.6",
         "phpspec/phpspec": "^4.2",
-        "phpstan/phpstan": "^0.9.0",
-        "phpstan/phpstan-phpunit": "^0.9.0",
+        "phpstan/phpstan": "^0.10.0",
+        "phpstan/phpstan-phpunit": "^0.10.0",
         "phpunit/phpunit": "^7.0",
         "slevomat/coding-standard": "^4.0",
         "squizlabs/php_codesniffer": "^3.1"

--- a/src/Commit/CommitDateType.php
+++ b/src/Commit/CommitDateType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\Commit;
 use DateTime;
 use DevboardLib\Git\Commit\CommitDate;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class CommitDateType extends DateTimeType
@@ -20,16 +19,6 @@ class CommitDateType extends DateTimeType
         }
 
         $val = CommitDate::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/Installation/InstallationCreatedAtType.php
+++ b/src/Installation/InstallationCreatedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\Installation;
 use DateTime;
 use DevboardLib\GitHub\Installation\InstallationCreatedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class InstallationCreatedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class InstallationCreatedAtType extends DateTimeType
         }
 
         $val = InstallationCreatedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/Installation/InstallationUpdatedAtType.php
+++ b/src/Installation/InstallationUpdatedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\Installation;
 use DateTime;
 use DevboardLib\GitHub\Installation\InstallationUpdatedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class InstallationUpdatedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class InstallationUpdatedAtType extends DateTimeType
         }
 
         $val = InstallationUpdatedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/Issue/IssueClosedAtType.php
+++ b/src/Issue/IssueClosedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\Issue;
 use DateTime;
 use DevboardLib\GitHub\Issue\IssueClosedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class IssueClosedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class IssueClosedAtType extends DateTimeType
         }
 
         $val = IssueClosedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/Issue/IssueCreatedAtType.php
+++ b/src/Issue/IssueCreatedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\Issue;
 use DateTime;
 use DevboardLib\GitHub\Issue\IssueCreatedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class IssueCreatedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class IssueCreatedAtType extends DateTimeType
         }
 
         $val = IssueCreatedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/Issue/IssueUpdatedAtType.php
+++ b/src/Issue/IssueUpdatedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\Issue;
 use DateTime;
 use DevboardLib\GitHub\Issue\IssueUpdatedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class IssueUpdatedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class IssueUpdatedAtType extends DateTimeType
         }
 
         $val = IssueUpdatedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/IssueComment/IssueCommentCreatedAtType.php
+++ b/src/IssueComment/IssueCommentCreatedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\IssueComment;
 use DateTime;
 use DevboardLib\GitHub\IssueComment\IssueCommentCreatedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class IssueCommentCreatedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class IssueCommentCreatedAtType extends DateTimeType
         }
 
         $val = IssueCommentCreatedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/IssueComment/IssueCommentUpdatedAtType.php
+++ b/src/IssueComment/IssueCommentUpdatedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\IssueComment;
 use DateTime;
 use DevboardLib\GitHub\IssueComment\IssueCommentUpdatedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class IssueCommentUpdatedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class IssueCommentUpdatedAtType extends DateTimeType
         }
 
         $val = IssueCommentUpdatedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/Milestone/MilestoneClosedAtType.php
+++ b/src/Milestone/MilestoneClosedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\Milestone;
 use DateTime;
 use DevboardLib\GitHub\Milestone\MilestoneClosedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class MilestoneClosedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class MilestoneClosedAtType extends DateTimeType
         }
 
         $val = MilestoneClosedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/Milestone/MilestoneCreatedAtType.php
+++ b/src/Milestone/MilestoneCreatedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\Milestone;
 use DateTime;
 use DevboardLib\GitHub\Milestone\MilestoneCreatedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class MilestoneCreatedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class MilestoneCreatedAtType extends DateTimeType
         }
 
         $val = MilestoneCreatedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/Milestone/MilestoneDueOnType.php
+++ b/src/Milestone/MilestoneDueOnType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\Milestone;
 use DateTime;
 use DevboardLib\GitHub\Milestone\MilestoneDueOn;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class MilestoneDueOnType extends DateTimeType
@@ -20,16 +19,6 @@ class MilestoneDueOnType extends DateTimeType
         }
 
         $val = MilestoneDueOn::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/Milestone/MilestoneUpdatedAtType.php
+++ b/src/Milestone/MilestoneUpdatedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\Milestone;
 use DateTime;
 use DevboardLib\GitHub\Milestone\MilestoneUpdatedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class MilestoneUpdatedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class MilestoneUpdatedAtType extends DateTimeType
         }
 
         $val = MilestoneUpdatedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/PullRequest/PullRequestClosedAtType.php
+++ b/src/PullRequest/PullRequestClosedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\PullRequest;
 use DateTime;
 use DevboardLib\GitHub\PullRequest\PullRequestClosedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class PullRequestClosedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class PullRequestClosedAtType extends DateTimeType
         }
 
         $val = PullRequestClosedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/PullRequest/PullRequestCreatedAtType.php
+++ b/src/PullRequest/PullRequestCreatedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\PullRequest;
 use DateTime;
 use DevboardLib\GitHub\PullRequest\PullRequestCreatedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class PullRequestCreatedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class PullRequestCreatedAtType extends DateTimeType
         }
 
         $val = PullRequestCreatedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/PullRequest/PullRequestUpdatedAtType.php
+++ b/src/PullRequest/PullRequestUpdatedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\PullRequest;
 use DateTime;
 use DevboardLib\GitHub\PullRequest\PullRequestUpdatedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class PullRequestUpdatedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class PullRequestUpdatedAtType extends DateTimeType
         }
 
         $val = PullRequestUpdatedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/PullRequestReview/PullRequestReviewSubmittedAtType.php
+++ b/src/PullRequestReview/PullRequestReviewSubmittedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\PullRequestReview;
 use DateTime;
 use DevboardLib\GitHub\PullRequestReview\PullRequestReviewSubmittedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class PullRequestReviewSubmittedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class PullRequestReviewSubmittedAtType extends DateTimeType
         }
 
         $val = PullRequestReviewSubmittedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/Repo/RepoCreatedAtType.php
+++ b/src/Repo/RepoCreatedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\Repo;
 use DateTime;
 use DevboardLib\GitHub\Repo\RepoCreatedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class RepoCreatedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class RepoCreatedAtType extends DateTimeType
         }
 
         $val = RepoCreatedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/Repo/RepoPushedAtType.php
+++ b/src/Repo/RepoPushedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\Repo;
 use DateTime;
 use DevboardLib\GitHub\Repo\RepoPushedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class RepoPushedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class RepoPushedAtType extends DateTimeType
         }
 
         $val = RepoPushedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }

--- a/src/Repo/RepoUpdatedAtType.php
+++ b/src/Repo/RepoUpdatedAtType.php
@@ -7,7 +7,6 @@ namespace DevboardLib\GitHubDoctrineType\Repo;
 use DateTime;
 use DevboardLib\GitHub\Repo\RepoUpdatedAt;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
 class RepoUpdatedAtType extends DateTimeType
@@ -20,16 +19,6 @@ class RepoUpdatedAtType extends DateTimeType
         }
 
         $val = RepoUpdatedAt::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if (!$val) {
-            $val = date_create($value);
-        }
-
-        if (!$val) {
-            throw ConversionException::conversionFailedFormat(
-                $value, $this->getName(), $platform->getDateTimeFormatString()
-            );
-        }
 
         return $val;
     }


### PR DESCRIPTION
Phpstan 0.10 is out and since it uses nikic/php-parser 4.x, we need to upgrade infection to 0.9 dev version too.